### PR TITLE
Add restaurant retention metrics view and display in Locations tab

### DIFF
--- a/streamlit/app.py
+++ b/streamlit/app.py
@@ -80,7 +80,20 @@ with tabs[3]:
 
 with tabs[4]:
     st.subheader("Location Performance")
-    df = run_query("SELECT * FROM default.gp_v_location_performance ORDER BY revenue_net DESC")
+    df = run_query(
+        """
+        SELECT p.restaurant_id,
+               p.revenue_net,
+               p.orders,
+               p.aov,
+               r.repeat_customer_rate,
+               r.orders_per_week
+        FROM default.gp_v_location_performance p
+        LEFT JOIN default.gp_v_location_retention r
+          ON p.restaurant_id = r.restaurant_id
+        ORDER BY p.revenue_net DESC
+        """
+    )
     st.dataframe(df)
 
 with tabs[5]:


### PR DESCRIPTION
## Summary
- add gp_v_location_retention view for repeat-customer rate and orders per week per restaurant
- join retention metrics into Streamlit Locations tab for sortable analysis

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68a9f26e599c832e85ae3ba4ba75170f